### PR TITLE
When collecting existing elements mark them as Revit owned.

### DIFF
--- a/src/RhythmRevit/Revit/Selection/Collector.cs
+++ b/src/RhythmRevit/Revit/Selection/Collector.cs
@@ -81,14 +81,6 @@ namespace Rhythm.Revit.Selection
                 doc = document as Document;
             }
 
-
-            if (DocumentManager.Instance.CurrentDBDocument.Equals(doc))
-            {
-                throw new Exception(
-                    "Rhythm for Dynamo: Sorry this node doesn't work for current documents. Please use All Elements of Category for this");
-            };
-
-
             if (category is null)
             {
                 throw new Exception(
@@ -105,7 +97,7 @@ namespace Rhythm.Revit.Selection
             FilteredElementCollector coll = new FilteredElementCollector(doc);
             List<global::Revit.Elements.Element> elems =
                 new List<global::Revit.Elements.Element>(coll.WhereElementIsNotElementType().WherePasses(filter).ToElements()
-                    .Select(e => e.ToDSType(false)));
+                    .Select(e => e.ToDSType(true)));
 
             return elems;
         }


### PR DESCRIPTION
This forum thread presents an interesting issue that I will try to explain here:
https://forum.dynamobim.com/t/bug-with-design-script-rhythm/95134/14

1. the user collects some `View` wrappers by using the `ElementsOfCategoryInDocument` on the current document.
2. Internally `ElementsOfCategoryInDocument` calls `ToDSType(false)` on the elements it collects - this has the consequence of marking the elements (the views in this case) as Dynamo owned.
3. When the user passes an incorrect type (null instead of category) to the `ElementsOfCategoryInDocument` method the existing view wrappers go out of scope.
4. When things go out of scope in Dynamo the GC will collect and dispose them. This is like deleting a node from the graph.
5. Because the view wrappers were created with `IsRevitOwned = false` - the underlying elements get deleted.  You can see the code in the element base class that does this: https://github.com/DynamoDS/DynamoRevit/blob/0c3fe5f2fd75d0fee9a3fbf991c30830017c05a7/src/Libraries/RevitNodes/Elements/Element.cs#L288

Is there a reason that you were using false here that I am missing or it just was not clear what to set that parameter to?

image shows the value being null but the views not getting deleted:

![Screenshot 2024-04-22 at 6 13 47 PM](https://github.com/johnpierson/RhythmForDynamo/assets/508936/060ce739-95da-477f-814c-fe1027b7013d)
