### PR TITLE
Licensing cleanup: fix contradictory copyright metadata, add third-party notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This tool is not affiliated with Autodesk and was written and provided in a pers
 [![GitHub license](https://img.shields.io/github/license/johnpierson/RhythmForDynamo)](https://github.com/johnpierson/RhythmForDynamo/blob/master/LICENSE)
 Rhythm is licensed under the BSD 3 Clause License. You can use this package however you want in Dynamo. It's just limited in the way the source code may be used. A simplified version of this license is available [here](https://www.tldrlegal.com/license/bsd-3-clause-license-revised).
 
+Rhythm also incorporates third-party code that is **not** covered by the BSD 3 Clause License and remains under its own terms — most notably a rectangle packer under the IBM Common Public License v1.0. See [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) for the full list.
+
 ## Current Version
  Supported Revit versions are 2020 and up. And supported Dynamo versions are Dynamo 2.0.x and up. Rhythm is deployed from github, and auto-downloads the correct node libraries on the fly. 
 

--- a/RhythmPython/FileSystem/zipDirectories.py
+++ b/RhythmPython/FileSystem/zipDirectories.py
@@ -6,7 +6,7 @@ __author__ = 'john pierson - sixtysecondrevit@gmail.com'
 __twitter__ = '@60secondrevit'
 __github__ = '@johnpierson'
 __version__ ='1.0.0'
-__license__ = 'GNU General Public License v3.0' 'https://choosealicense.com/licenses/gpl-3.0/'
+__license__ = 'BSD 3-Clause - https://tldrlegal.com/license/bsd-3-clause-license-(revised)'
 
 # import common language runtime and system
 import clr

--- a/RhythmPython/Revit/Application/unloadLinksFromFile.py
+++ b/RhythmPython/Revit/Application/unloadLinksFromFile.py
@@ -7,7 +7,7 @@ __author__ = 'john pierson - sixtysecondrevit@gmail.com'
 __twitter__ = '@60secondrevit'
 __github__ = '@johnpierson'
 __version__ ='1.0.0'
-__license__ = 'GNU General Public License v3.0' 'https://choosealicense.com/licenses/gpl-3.0/'
+__license__ = 'BSD 3-Clause - https://tldrlegal.com/license/bsd-3-clause-license-(revised)'
 
 # import common language runtime 
 import clr

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,271 @@
+# Third-Party Notices
+
+Rhythm for Dynamo is distributed under the BSD 3-Clause License (see [LICENSE](LICENSE)).
+That license covers Rhythm's own code. It does **not** cover the third-party code
+listed below, which is incorporated into this repository and, in most cases,
+compiled into the shipped assemblies. Each item remains under its own license and
+its own copyright holder.
+
+This file is informational and does not modify any of the licenses referenced.
+
+Last reviewed: 2026-08-01
+
+---
+
+## Contents
+
+1. [Nuclex Framework — rectangle packing](#1-nuclex-framework--rectangle-packing) — **IBM Common Public License v1.0**
+2. [ShortestWalk](#2-shortestwalk) — MIT
+3. [Revit MEP API sample forms](#3-revit-mep-api-sample-forms) — Autodesk sample terms
+4. [Point-in-polygon test](#4-point-in-polygon-test) — permissive, notice must be preserved
+5. [Gaussian-Random](#5-gaussian-random) — MIT
+6. [polylabel-csharp](#6-polylabel-csharp) — **no license stated upstream**
+7. [SpringNodes](#7-springnodes) — MIT
+8. [Community-contributed snippets](#8-community-contributed-snippets)
+9. [LunchboxML](#9-lunchboxml-not-shipped) — LGPL, **not shipped**
+10. [Redistributed binaries](#10-redistributed-binaries) — MIT
+11. [Build-time dependencies](#11-build-time-dependencies-not-redistributed)
+
+---
+
+## 1. Nuclex Framework — rectangle packing
+
+**Copyright (C) 2002-2011 Nuclex Development Labs**
+**License: IBM Common Public License v1.0 (CPL-1.0)**
+
+> ⚠️ **This is the most significant item in this file.** The CPL is a weak-copyleft
+> license, not a permissive one. These files are compiled into the shipped
+> `RhythmCore.dll` and `RhythmRevit.dll`. They are **not** BSD 3-Clause and are not
+> covered by Rhythm's LICENSE file. Obligations under CPL-1.0 attach to these files
+> and to modifications of them.
+
+Files (six; the set is duplicated across both projects):
+
+- `src/RhythmCore/GenerativeDesign/CygonRectanglePacker.cs`
+- `src/RhythmCore/GenerativeDesign/RectanglePacker.cs`
+- `src/RhythmCore/GenerativeDesign/OutOfSpaceException.cs`
+- `src/RhythmRevit/Revit/Views/CygonRectanglePacker.cs`
+- `src/RhythmRevit/Revit/Views/RectanglePacker.cs`
+- `src/RhythmRevit/Revit/Views/OutOfSpaceException.cs`
+
+Each file carries its original `#region CPL License` header, which reads in part:
+
+```
+Nuclex Framework
+Copyright (C) 2002-2011 Nuclex Development Labs
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the IBM Common Public License as
+published by the IBM Corporation; either version 1.0 of the
+License, or (at your option) any later version.
+```
+
+The code has been adapted for Dynamo geometry types (the original XNA
+`Microsoft.Xna.Framework` dependency is commented out), but the namespace
+`Nuclex.Game.Packing` and the license headers are intact.
+
+Full license text: <https://opensource.org/license/cpl1-0-txt>
+
+---
+
+## 2. ShortestWalk
+
+**Copyright (c) 2011 McNeel Europe. All Rights Reserved.**
+**License: MIT** (see [MIT License text](#mit-license-text) below)
+
+A port of the RhinoCommon/Grasshopper *ShortestWalk* component, originally written
+by Giulio Piacentino of Robert McNeel & Associates, adapted here to Dynamo's
+`Autodesk.DesignScript.Geometry` types. Reached Rhythm by way of Proving Ground's
+open-sourced LunchBox package.
+
+Files (nine, approximately 1,030 lines):
+
+- `src/RhythmRevit/ShortestWalk/Geometry/AStar.cs`
+- `src/RhythmRevit/ShortestWalk/Geometry/CurvesTopology.cs`
+- `src/RhythmRevit/ShortestWalk/Geometry/Dijkstra.cs`
+- `src/RhythmRevit/ShortestWalk/Geometry/EdgeAddress.cs`
+- `src/RhythmRevit/ShortestWalk/Geometry/ListByPattern.cs`
+- `src/RhythmRevit/ShortestWalk/Geometry/NodeAddress.cs`
+- `src/RhythmRevit/ShortestWalk/Geometry/PathMethod.cs`
+- `src/RhythmRevit/ShortestWalk/Geometry/SearchMode.cs`
+- `src/RhythmRevit/Utilities/ShortestWalkUtils.cs` (Dynamo adapter over the above)
+
+Exposed to users through `Rhythm.Geometry.Geometry.LunchboxShortestWalk`.
+
+> **Note:** none of these files currently carries a copyright header, even though the
+> upstream MIT terms require that "the above copyright notice and this permission
+> notice shall be included in all copies or substantial portions of the Software."
+> The notice below satisfies that requirement at the distribution level; adding
+> per-file headers would be an improvement.
+
+Upstream: <https://github.com/shortestwalk-demo/ShortestWalk>
+
+---
+
+## 3. Revit MEP API sample forms
+
+**Copyright (C) 2007-2010 by Jeremy Tammik, Autodesk, Inc.**
+**License: Autodesk sample-code terms (permissive, notice must be preserved)**
+
+Files:
+
+- `src/RhythmRevit/Forms/DefaultProgressForm.cs`
+- `src/RhythmRevit/Forms/FamilyUpgradeForm.cs`
+
+Both retain their original `#region Header` block, which grants permission to
+"use, copy, modify, and distribute this software for any purpose and without fee
+[...] provided that the above copyright notice appears in all copies", and includes
+Autodesk's warranty disclaimer and U.S. Government restricted-rights notice.
+
+---
+
+## 4. Point-in-polygon test
+
+**Copyright (C) 2009 by Jeremy Tammik. All rights reserved.**
+**License: permissive — "This code may be freely used. Please preserve this comment."**
+
+File: `src/RhythmRevit/Utilities/PointInPoly.cs` (method `PolygonContains`)
+
+Per its header, written by Jeremy Tammik (Autodesk, 2009-09-23), based on his own
+1996 C++ code, which in turn derived from C code in the article *"An Incremental
+Angle Point in Polygon Test"* by Kevin Weiler, Autodesk, in **Graphics Gems IV**
+(Academic Press, 1994).
+
+---
+
+## 5. Gaussian-Random
+
+**Copyright (c) Marco Fazio Random**
+**License: MIT** (see [MIT License text](#mit-license-text) below)
+
+File: `src/RhythmCore/GenerativeDesign/GenerativeDesign.cs` — the
+`RandomDistribution` class (Marsaglia polar-method Gaussian sampling).
+
+Attribution is recorded inline on the class. Upstream:
+<https://github.com/MarcoFazioRandom/Gaussian-Random>
+
+---
+
+## 6. polylabel-csharp
+
+**Author: eqmiller**
+**License: ⚠️ not stated upstream**
+
+Files:
+
+- `src/RhythmCore/Polylabel/Cell.cs`
+- `src/RhythmCore/Polylabel/Polylabel.cs`
+
+A C# port of Mapbox's [polylabel](https://github.com/mapbox/polylabel) (pole-of-
+inaccessibility) algorithm; the upstream JavaScript/C++ original is ISC-licensed.
+Used by `Rhythm.Geometry.Polygon`.
+
+> ⚠️ **Flagged:** the upstream repository <https://github.com/eqmiller/polylabel-csharp>
+> publishes **no LICENSE file and no license statement**. Absent an express grant,
+> the default position is that no redistribution rights were given. Options worth
+> considering: ask the author to add a license, re-derive the ~220 lines directly
+> from Mapbox's ISC-licensed original, or replace the implementation.
+
+---
+
+## 7. SpringNodes
+
+**Copyright (c) Dimitar Venkov**
+**License: MIT** (see [MIT License text](#mit-license-text) below)
+
+`Rhythm.Revit.Elements.FamilyInstance.ByGeometry` in
+`src/RhythmRevit/Revit/Elements/FamilyInstance.cs` is a C# reimplementation of the
+approach in SpringNodes' `FamilyInstance.ByGeometry.py`. Attribution is recorded
+inline. Upstream: <https://github.com/dimven/SpringNodes>
+
+---
+
+## 8. Community-contributed snippets
+
+Code adapted from publicly posted community contributions. Attribution is recorded
+inline in each file; no formal license was attached at the source.
+
+- **`src/RhythmRevit/Utilities/Converters.cs`** — Dynamo/Revit type converters
+  contributed by **@erfajo** on the Dynamo forum.
+  <https://forum.dynamobim.com/t/the-fusion-post-for-coders/78033>
+- **`src/RhythmRevit/Revit/Elements/FilledRegion.cs`** — multi-loop filled-region
+  creation, based on a Dynamo forum post.
+  <https://forum.dynamobim.com/t/filled-region-with-hole-in-the-middle-like-a-donut/22838/3>
+
+---
+
+## 9. LunchboxML (not shipped)
+
+**License: GNU Lesser General Public License (LGPL)**
+
+File: `src/RhythmCore/ML/ML.cs`
+
+> **Not shipped.** This file is **100% commented out** — every line, including the
+> `using` directives — and contributes no code to any built assembly. It is retained
+> only as a reference to a Gaussian Mixture classification node made possible by
+> LunchboxML (<https://bitbucket.org/archinate/lunchboxml/src/master/>), which is
+> LGPL-licensed.
+>
+> Listed here for completeness. If this node is ever revived, the LGPL implications
+> must be addressed first, since LGPL is incompatible with shipping the code as
+> BSD 3-Clause.
+
+---
+
+## 10. Redistributed binaries
+
+These third-party assemblies are shipped alongside Rhythm in the `deploy/` folder.
+Both are MIT-licensed (see [MIT License text](#mit-license-text) below).
+
+| Component | Version | Copyright | Project |
+| --- | --- | --- | --- |
+| Humanizer | 2.14.1 | Copyright (c) .NET Foundation and Contributors | <https://github.com/Humanizr/Humanizer> |
+| Markov | 2.0.0 | Copyright (c) 2018 John Gietzen and Contributors | <https://github.com/otac0n/markov> |
+
+---
+
+## 11. Build-time dependencies (not redistributed)
+
+Referenced at build time and **not** redistributed by this repository. Each remains
+under its own license, obtained from its own publisher:
+
+Dynamo (`DynamoVisualProgramming.*`), Revit API
+(`Nice3point.Revit.Api.*`, `Revit_All_Main_Versions_API_x64`), `Newtonsoft.Json`,
+`Prism`, `CommonServiceLocator`, `OptimizedPriorityQueue`, `NUnit`, and the
+`System.*` / `Microsoft.CSharp` packages.
+
+---
+
+## MIT License Text
+
+The following is the standard MIT License text referenced by items 2, 5, 7 and 10
+above. Substitute the copyright line given for each component.
+
+```
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## Reporting
+
+If you are a copyright holder listed here and something is attributed
+incorrectly — or if you spot third-party code in this repository that is missing
+from this file — please open an issue at
+<https://github.com/johnpierson/RhythmForDynamo/issues>.

--- a/deploy/Rhythm/pkg.json
+++ b/deploy/Rhythm/pkg.json
@@ -31,6 +31,6 @@
     "RhythmRevit, Version=2024.10.1.0, Culture=neutral, PublicKeyToken=null",
     "RhythmUI, Version=2024.10.1.0, Culture=neutral, PublicKeyToken=null"
   ],
-  "copyright_holder": "j0hnp",
-  "copyright_year": "2024"
+  "copyright_holder": "John Pierson",
+  "copyright_year": "2019"
 }

--- a/deploy/pkg.json
+++ b/deploy/pkg.json
@@ -31,6 +31,6 @@
     "RhythmRevit, Version=2024.10.1.0, Culture=neutral, PublicKeyToken=null",
     "RhythmUI, Version=2024.10.1.0, Culture=neutral, PublicKeyToken=null"
   ],
-  "copyright_holder": "j0hnp",
-  "copyright_year": "2025"
+  "copyright_holder": "John Pierson",
+  "copyright_year": "2019"
 }

--- a/src/RhythmCore/Properties/AssemblyInfo.cs
+++ b/src/RhythmCore/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyCopyright("Copyright (c) 2019 John Pierson")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/RhythmCore/RhythmCore.csproj
+++ b/src/RhythmCore/RhythmCore.csproj
@@ -139,7 +139,8 @@
         <DynVersion>$(DynamoVersion)</DynVersion>
         <BuildOutput>$(DynamoOutput)</BuildOutput>
         <PublishSingleFile>true</PublishSingleFile>
-        <Copyright>MIT</Copyright>
+        <Copyright>Copyright (c) 2019 John Pierson</Copyright>
+        <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>dynamo</PackageTags>
         <FolderPackages>$(Appdata)\Dynamo\Dynamo Revit\$(BuildOutput)\packages\Rhythm\</FolderPackages>

--- a/src/RhythmExtension/Properties/AssemblyInfo.cs
+++ b/src/RhythmExtension/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyCopyright("Copyright (c) 2019 John Pierson")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/RhythmExtension/RhythmExtension.csproj
+++ b/src/RhythmExtension/RhythmExtension.csproj
@@ -7,7 +7,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyTitle>RhythmExtension.2024</AssemblyTitle>
     <Product>RhythmExtension.2024</Product>
-    <Copyright>Copyright ©  2023</Copyright>
+    <Copyright>Copyright (c) 2019 John Pierson</Copyright>
  <Configurations>Debug R25;</Configurations>
         <Configurations>$(Configurations)Release R25;</Configurations>
   </PropertyGroup>
@@ -29,7 +29,7 @@
     <DynVersion>$(DynamoVersion)</DynVersion>
 	<AssemblyTitle>Rhythm for Dynamo| Extension</AssemblyTitle>
 	<Product>Rhythm for Dynamo| Extension</Product>
-	<Copyright>Copyright ©  2023</Copyright>
+	<Copyright>Copyright (c) 2019 John Pierson</Copyright>
 	<AssemblyVersion>2023.9.1</AssemblyVersion>
 	<FileVersion>2023.9.1</FileVersion>
   </PropertyGroup>

--- a/src/RhythmRevit/Properties/AssemblyInfo.cs
+++ b/src/RhythmRevit/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyCopyright("Copyright (c) 2019 John Pierson")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/RhythmRevit/RhythmRevit.csproj
+++ b/src/RhythmRevit/RhythmRevit.csproj
@@ -146,7 +146,8 @@
         <DynRevitVersion Condition="'$(DynRevitVersion)' == ''">$(DynamoVersion)</DynRevitVersion>
         <BuildOutput>$(DynamoOutput)</BuildOutput>
         <PublishSingleFile>true</PublishSingleFile>
-        <Copyright>MIT</Copyright>
+        <Copyright>Copyright (c) 2019 John Pierson</Copyright>
+        <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>dynamo</PackageTags>
         <FolderPackages>$(Appdata)\Dynamo\Dynamo Revit\$(BuildOutput)\packages\RhythmRevit\</FolderPackages>

--- a/src/RhythmUI/Properties/AssemblyInfo.cs
+++ b/src/RhythmUI/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyCopyright("Copyright (c) 2019 John Pierson")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/RhythmUI/RhythmUI - Backup.csproj
+++ b/src/RhythmUI/RhythmUI - Backup.csproj
@@ -109,7 +109,8 @@
         <DynVersion>$(DynamoVersion)</DynVersion>
         <BuildOutput>$(DynamoOutput)</BuildOutput>
         <PublishSingleFile>true</PublishSingleFile>
-        <Copyright>MIT</Copyright>
+        <Copyright>Copyright (c) 2019 John Pierson</Copyright>
+        <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>dynamo</PackageTags>
         <FolderPackages>$(Appdata)\Dynamo\Dynamo Revit\$(BuildOutput)\packages\Rhythm\</FolderPackages>

--- a/src/RhythmUI/RhythmUI.csproj
+++ b/src/RhythmUI/RhythmUI.csproj
@@ -138,7 +138,8 @@
         <DynVersion>$(DynamoVersion)</DynVersion>
         <BuildOutput>$(DynamoOutput)</BuildOutput>
         <PublishSingleFile>true</PublishSingleFile>
-        <Copyright>MIT</Copyright>
+        <Copyright>Copyright (c) 2019 John Pierson</Copyright>
+        <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>dynamo</PackageTags>
         <FolderPackages>$(Appdata)\Dynamo\Dynamo Revit\$(BuildOutput)\packages\Rhythm\</FolderPackages>

--- a/src/RhythmViewExtension/Properties/AssemblyInfo.cs
+++ b/src/RhythmViewExtension/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Rhythm for Dynamo")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Design Tech Unraveled")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyCopyright("Copyright (c) 2019 John Pierson")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/RhythmViewExtension/RhythmViewExtension.csproj
+++ b/src/RhythmViewExtension/RhythmViewExtension.csproj
@@ -45,7 +45,7 @@
     <DynVersion>$(DynamoVersion)</DynVersion>
 	<AssemblyTitle>Rhythm for Dynamo| View Extension</AssemblyTitle>
 	<Product>Rhythm for Dynamo| View Extension</Product>
-	<Copyright>Copyright ©  2023</Copyright>
+	<Copyright>Copyright (c) 2019 John Pierson</Copyright>
 	<AssemblyVersion>2025.10.1</AssemblyVersion>
 	<FileVersion>2025.10.1</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fixes a set of licensing inconsistencies found during a read-only audit of the repo. Four commits, each independently reviewable.

## Why

The repo ships under BSD 3-Clause ([LICENSE](LICENSE), 2019 John Pierson), but the metadata said otherwise in several places, and there was no third-party notices file despite a meaningful amount of vendored third-party source — including weak-copyleft code compiled into the shipped DLLs.

## What changed

### 1. csproj `<Copyright>` said "MIT" (`0faaf86`)

`RhythmCore`, `RhythmRevit` and `RhythmUI` (plus `RhythmUI - Backup`) all had `<Copyright>MIT</Copyright>` — a license name in a copyright field, and the wrong license. Replaced with `Copyright (c) 2019 John Pierson`, matching LICENSE.

Since the underlying problem was a license name stuffed into a copyright field, I also added `<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>`, which is the field that actually exists for this. Verified both evaluate correctly with `dotnet msbuild -getProperty`. Swept the other three csproj files — no other project had the same problem.

### 2. Correction: the csproj `<Copyright>` never reached the DLLs (`a10bc92`)

Worth flagging, because it changes what the real problem was.

All five projects set `GenerateAssemblyInfo=False`. That means `Properties/AssemblyInfo.cs` — not the csproj `<Copyright>` property — supplies `AssemblyCopyrightAttribute`. Confirmed against a built binary:

```
deploy/2020/RhythmCore.dll  ->  LegalCopyright: 'Copyright ©  2023'
```

So "MIT" was never baked into a shipped assembly. It was NuGet pack metadata that contradicted LICENSE — still worth fixing, but not the thing users' DLLs carried.

What *was* shipping is the untouched Visual Studio placeholder `Copyright ©  2023`: no holder name, and a year matching neither LICENSE nor anything else. Normalized across all five `AssemblyInfo.cs` files, the two extension csproj files, and both Dynamo package manifests (`deploy/pkg.json`, `deploy/Rhythm/pkg.json`, which had `copyright_holder: "j0hnp"` with years 2024/2025).

CI only builds DLLs into `deploy/<version>/` — it does not regenerate `pkg.json` — so these edits persist. Metadata strings only; no behavioural or version changes.

### 3. Two RhythmPython files marked GPL-3.0 (`05c04ab`)

`RhythmPython/FileSystem/zipDirectories.py` and `RhythmPython/Revit/Application/unloadLinksFromFile.py` declared `__license__ = 'GNU General Public License v3.0'`, incompatible with BSD-3.

I investigated provenance before touching either, since silently relicensing someone else's code would be the worse error. Findings:

- Both were created from scratch in this repo (`d20bdcb`, `fbaa69f`, July 2021) — not imported.
- `__author__` is John Pierson on both.
- Neither derives from third-party code: `zipDirectories` wraps `System.IO.Compression.ZipFile`; `unloadLinksFromFile` wraps the Revit `TransmissionData` API. No upstream reference in either file.
- Both carry the *identical* GPL string and come from the same batch — consistent with a copy-paste slip in the header template.
- Every other RhythmPython file with a marker declares BSD 3-Clause.

Corrected to the same BSD-3 string the other RhythmPython files use. This is the author's own marker on the author's own code — no third-party code was relicensed.

### 4. Added `THIRD-PARTY-NOTICES.md` (`f92d319`)

Covers eleven items. Beyond those already known, my sweep turned up three the audit had missed:

- **ShortestWalk** — ~1,030 lines across nine files (`src/RhythmRevit/ShortestWalk/`, `Utilities/ShortestWalkUtils.cs`), compiled into `RhythmRevit.dll`. MIT, © 2011 McNeel Europe — Giulio Piacentino's Grasshopper component, arrived via Proving Ground's LunchBox.
- **polylabel-csharp** (`src/RhythmCore/Polylabel/`) — upstream publishes no license at all.
- **SpringNodes** (MIT), @erfajo's Dynamo-forum converters, and two forum-sourced snippets.

Also documents the redistributed **Humanizer** and **Markov** binaries in `deploy/` (both MIT), and notes that the LGPL **LunchboxML** file is 100% commented out and contributes nothing to any build.

The Nuclex rectangle packer (IBM CPL-1.0, six files) is called out at the top with a warning rather than buried in a flat list, since it's the one item with real copyleft implications.

Added a pointer from the README's License section so the BSD-3 claim is qualified where readers actually encounter it.

All licenses were verified against file headers or upstream sources rather than assumed; all 25 referenced file paths verified to exist. No existing inline license headers were stripped.

## Needs your decision

Three items I deliberately did **not** act on. Each is disclosed accurately in the notices file, but each needs a call from you.

**ShortestWalk is missing its MIT headers.** Upstream MIT requires that "the above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software." None of the nine vendored files carries any copyright header. The notices file satisfies this at the distribution level, but adding per-file headers would be the cleaner fix. I left the files alone rather than editing headers into nine files of someone else's code without asking.

**polylabel-csharp has no upstream license.** <https://github.com/eqmiller/polylabel-csharp> publishes no LICENSE file and no license statement. Absent an express grant, the default position is that no redistribution rights were given — so this is arguably the highest-risk item in the repo, ahead of the CPL code. It's ~220 lines used by `Rhythm.Geometry.Polygon`. Options: ask the author to add a license, re-derive it from Mapbox's ISC-licensed original, or replace the implementation.

**Nuclex CPL-1.0 code is disclosed, not removed.** Six files under IBM Common Public License v1.0 — weak copyleft — compiled into both shipped DLLs, duplicated across `RhythmCore/GenerativeDesign/` and `RhythmRevit/Revit/Views/`. Swapping out a rectangle packer that both DLLs depend on is a code change with behavioural risk, not a licensing cleanup. Your call whether to replace it or accept the CPL obligations; this PR only makes the situation visible.

## Testing

No end-to-end build was run — the changes are metadata strings plus one new markdown file, and a full build needs the Revit/Dynamo SDKs. Verified instead:

- All four modified csproj files still parse as well-formed XML.
- Both `pkg.json` files still parse as valid JSON.
- `dotnet msbuild -getProperty:Copyright -getProperty:PackageLicenseExpression` returns the expected values.
- No stale `Copyright ©  2023`, `<Copyright>MIT<`, or `j0hnp` markers remain anywhere in `src/` or `deploy/`.
- Every file path referenced in the notices file exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
