### PR TITLE
fix: load the tag family whenever the dialog is opened

### DIFF
--- a/deploy/Rhythm/doc/Rhythm.Revit.Tools.Tools.ThreeDeeSpatialTags.md
+++ b/deploy/Rhythm/doc/Rhythm.Revit.Tools.Tools.ThreeDeeSpatialTags.md
@@ -6,6 +6,8 @@ Open the 3d Spatial Tags dialog, and report what it did.
 
 This is the 3d Spatial Tags add-in as a single node: the same dialog, drawn the same way, doing the same work. Set runIt to true and it opens over Revit. Pick rooms or spaces, optionally a linked model to read them out of, the phase, the tag family type and a text height, then press Create / Update Tags. Close it and the node reports what the run did.
 
+The tag family loads itself. Opening the dialog puts the one Rhythm ships into the model if it is not already there, and replaces an older copy of it with the current one, so the family type list is never empty and never offers a family this node cannot write to. Type parameter values already set on it — text height, materials, visibility — are left as the user set them.
+
 Re-running follows the model rather than piling up duplicates: a tag records the element it belongs to, and the link instance it was read through, in the family's SpatialElementId parameter. Rooms with a blank name or number are skipped, because there would be nothing to put in the tag, and so are unplaced ones, because there is nowhere to put it. Unbounded and redundant rooms still have a marker, so they are still tagged, and the dialog says how many. In a workshared model a tag owned by somebody else is reported, never overwritten. Tags whose room has been deleted are counted and left alone, because deleting elements out of somebody's model is not this node's business.
 
 The dialog opens whenever this node evaluates with runIt true, so drive it from a Boolean toggle rather than from something that changes on every graph run.

--- a/docs/nodes/Rhythm.Revit.Tools.Tools.ThreeDeeSpatialTags.md
+++ b/docs/nodes/Rhythm.Revit.Tools.Tools.ThreeDeeSpatialTags.md
@@ -6,6 +6,8 @@ Open the 3d Spatial Tags dialog, and report what it did.
 
 This is the 3d Spatial Tags add-in as a single node: the same dialog, drawn the same way, doing the same work. Set runIt to true and it opens over Revit. Pick rooms or spaces, optionally a linked model to read them out of, the phase, the tag family type and a text height, then press Create / Update Tags. Close it and the node reports what the run did.
 
+The tag family loads itself. Opening the dialog puts the one Rhythm ships into the model if it is not already there, and replaces an older copy of it with the current one, so the family type list is never empty and never offers a family this node cannot write to. Type parameter values already set on it — text height, materials, visibility — are left as the user set them.
+
 Re-running follows the model rather than piling up duplicates: a tag records the element it belongs to, and the link instance it was read through, in the family's SpatialElementId parameter. Rooms with a blank name or number are skipped, because there would be nothing to put in the tag, and so are unplaced ones, because there is nowhere to put it. Unbounded and redundant rooms still have a marker, so they are still tagged, and the dialog says how many. In a workshared model a tag owned by somebody else is reported, never overwritten. Tags whose room has been deleted are counted and left alone, because deleting elements out of somebody's model is not this node's business.
 
 The dialog opens whenever this node evaluates with runIt true, so drive it from a Boolean toggle rather than from something that changes on every graph run.

--- a/src/RhythmRevit/Revit/Tools/SpatialTagging/OverwriteFamilyDefinition.cs
+++ b/src/RhythmRevit/Revit/Tools/SpatialTagging/OverwriteFamilyDefinition.cs
@@ -1,0 +1,50 @@
+// The 3d spatial tagging node, and the planning it is built on, are Revit 2025 and up.
+// The tag family it places is saved in Revit 2025, and Revit loads families forward but never
+// backward, so there is nothing for an earlier version to place.
+#if R25_OR_GREATER
+using Autodesk.Revit.DB;
+
+namespace Rhythm.Revit.Tools.SpatialTagging
+{
+    /// <summary>
+    /// Answers Revit's "this family is already in the project" question, so it is not asked.
+    ///
+    /// It has to be answered by something. Calling LoadFamily without load options puts Revit's own
+    /// dialog on screen the moment a model already carries a family of this name, and the user gets
+    /// a prompt about a file they never chose to load, in the middle of opening a different dialog.
+    ///
+    /// The definition is taken, the values are not. Those are two separate answers and they pull in
+    /// opposite directions here:
+    ///
+    /// Taking the definition is the whole point. The family already in a model is very often the
+    /// older one Rhythm has always shipped, which has no SpatialElementId parameter — so a run
+    /// against it rolls back and reports a missing parameter. The newer definition is what puts
+    /// that parameter there, and with it every existing tag becomes something a later run can find
+    /// and update rather than duplicate.
+    ///
+    /// Keeping the values is what stops that being rude. Type parameter values are the user's:
+    /// their text height, their materials, their visibility switches. Overwriting them would resize
+    /// and restyle every tag already standing in the model as a side effect of opening a dialog,
+    /// which is not what anybody asked for.
+    /// </summary>
+    internal class OverwriteFamilyDefinition : IFamilyLoadOptions
+    {
+        public bool OnFamilyFound(bool familyInUse, out bool overwriteParameterValues)
+        {
+            overwriteParameterValues = false;
+
+            return true;
+        }
+
+        public bool OnSharedFamilyFound(Family sharedFamily, bool familyInUse, out FamilySource source, out bool overwriteParameterValues)
+        {
+            // FamilySource.Family, so the definition being loaded wins over the copy in the project,
+            // which is the same answer OnFamilyFound gives and for the same reason.
+            source = FamilySource.Family;
+            overwriteParameterValues = false;
+
+            return true;
+        }
+    }
+}
+#endif

--- a/src/RhythmRevit/Revit/Tools/SpatialTagging/SpatialTagModel.cs
+++ b/src/RhythmRevit/Revit/Tools/SpatialTagging/SpatialTagModel.cs
@@ -200,15 +200,35 @@ namespace Rhythm.Revit.Tools.SpatialTagging
         /// </summary>
         public ObservableCollection<FamilySymbol> CollectTagFamilySymbols()
         {
-            var tags = FindTagSymbols();
+            if (!CurrentFamilyIsLoaded()) LoadBundledFamily();
 
-            if (!tags.Any())
-            {
-                LoadBundledFamily();
-                tags = FindTagSymbols();
-            }
+            return new ObservableCollection<FamilySymbol>(FindTagSymbols());
+        }
 
-            return new ObservableCollection<FamilySymbol>(tags);
+        /// <summary>
+        /// Whether the family already in the document is the one this node writes to.
+        ///
+        /// Asking "is a family called 3dSpatialElementTag loaded" is not the same question, and
+        /// answering that one instead is what made this go wrong: a model carrying the older family
+        /// Rhythm has always shipped in extra/ — the one the superseded ThreeDeeRoomTags and
+        /// ThreeDeeSpaceTags nodes point people at — matched by name, so nothing was loaded, and
+        /// the run then rolled itself back complaining about a missing SpatialElementId. The user
+        /// is told to add a parameter to a family they never chose.
+        ///
+        /// SpatialElementId is an instance parameter, and a family symbol does not carry instance
+        /// parameters, so a placed tag is the only thing that can answer. A model with the family
+        /// loaded but nothing placed yet cannot be judged either way and is reloaded, which costs
+        /// one undo entry and guarantees the right family.
+        /// </summary>
+        private bool CurrentFamilyIsLoaded()
+        {
+            if (!FindTagSymbols().Any()) return false;
+
+            var placed = new FilteredElementCollector(Doc).OfClass(typeof(FamilyInstance))
+                .WhereElementIsNotElementType().Cast<FamilyInstance>()
+                .FirstOrDefault(f => f.Symbol.Family.Name.IndexOf(TagFamilyName, StringComparison.OrdinalIgnoreCase) >= 0);
+
+            return placed != null && placed.LookupParameter(SpatialElementIdParameter) != null;
         }
 
         private List<FamilySymbol> FindTagSymbols()
@@ -280,7 +300,13 @@ namespace Rhythm.Revit.Tools.SpatialTagging
 
                     if (t.GetStatus() != TransactionStatus.Started) return;
 
-                    if (Doc.LoadFamily(path)) t.Commit();
+                    // The overload taking load options, not the bare one. Without them Revit puts
+                    // its own "family already exists" dialog up the moment a model already has a
+                    // family of this name, which is the case this whole path exists to handle, and
+                    // the user gets a prompt about a file they did not ask to load.
+                    Family loaded;
+
+                    if (Doc.LoadFamily(path, new OverwriteFamilyDefinition(), out loaded)) t.Commit();
                     else t.RollBack();
                 }
             }

--- a/src/RhythmRevit/Revit/Tools/SpatialTags.cs
+++ b/src/RhythmRevit/Revit/Tools/SpatialTags.cs
@@ -27,6 +27,12 @@ namespace Rhythm.Revit.Tools
         /// and a text height, then press Create / Update Tags. Close it and the node reports what
         /// the run did.
         ///
+        /// The tag family loads itself. Opening the dialog puts the one Rhythm ships into the model
+        /// if it is not already there, and replaces an older copy of it with the current one, so
+        /// the family type list is never empty and never offers a family this node cannot write to.
+        /// Type parameter values already set on it — text height, materials, visibility — are left
+        /// as the user set them.
+        ///
         /// Re-running follows the model rather than piling up duplicates: a tag records the element
         /// it belongs to, and the link instance it was read through, in the family's
         /// SpatialElementId parameter. Rooms with a blank name or number are skipped, because there


### PR DESCRIPTION
Opening the dialog only loaded the bundled family when nothing called 3dSpatialElementTag was in the model at all. A model already carrying the older family Rhythm ships in extra/ - the one the superseded ThreeDeeRoomTags and ThreeDeeSpaceTags nodes point people at - matched that check by name, so nothing was loaded. It has no SpatialElementId parameter, so the run then rolled itself back and told the user to add a parameter to a family they never chose.

Matching on the name was the wrong question. What matters is whether the family in the model is the one this node writes to, which is answered by looking for that parameter on a placed tag; a symbol cannot answer, because it is an instance parameter. Anything else, including a model with the family loaded but nothing placed yet, gets the current family loaded over it.

Loading over an existing family needs an answer to Revit's "already in the project" question, or Revit asks the user about a file they did not choose to load. The definition is taken and the values are not: the newer definition is what puts SpatialElementId there, and with it every tag already standing becomes something a later run can find and update rather than duplicate, while the text height, materials and visibility switches stay as the user set them.